### PR TITLE
feat: Add missing Meshy API endpoints and fix animation path bug

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,39 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+MCP (Model Context Protocol) server wrapping the [Meshy AI API](https://docs.meshy.ai/) for generative 3D tools. Published as an npm package (`meshy-ai-mcp-server`) and run via `npx` or locally by MCP clients (Claude Desktop, Cursor, etc.).
+
+## Commands
+
+- **Build:** `npm run build` (runs `tsc`)
+- **Dev:** `npm run dev` (runs `ts-node --esm src/index.ts`)
+- **Start:** `npm run start` (runs compiled `dist/index.js`)
+
+No test framework is configured. No linter is configured.
+
+## Architecture
+
+This is an ESM TypeScript project (`"type": "module"`) with two source files:
+
+- **`src/client.ts`** — `MeshyClient` class: HTTP client for the Meshy REST API. Handles GET/POST requests with Bearer auth, query parameter building, and SSE streaming. Stream responses are parsed for `data:` lines and terminate on `SUCCEEDED`/`FAILED`/`CANCELED` status.
+
+- **`src/index.ts`** — Server entrypoint (has shebang for CLI use). Creates an `McpServer` instance using `@modelcontextprotocol/sdk`, registers 25 tools covering 6 Meshy API domains (text-to-3d, image-to-3d, text-to-texture, remesh, rigging, animation) plus a balance check. Connects via `StdioServerTransport`. Each tool handler delegates to `MeshyClient` and wraps results with `jsonResponse()`.
+
+### Tool Registration Pattern
+
+All tools follow the same pattern: `server.registerTool(name, { description, inputSchema: z.object({...}) }, async handler)`. The handler calls `client.get()`, `client.post()`, or `client.stream()` and wraps the result in `jsonResponse()`. When adding new Meshy API endpoints, follow this existing pattern.
+
+### API Versioning
+
+Text-to-3D uses `/v2/`, all other endpoints use `/v1/`. Preserve this when adding tools.
+
+## Environment Variables
+
+- `MESHY_API_KEY` (required) — API key from Meshy dashboard
+- `MESHY_API_BASE` (optional) — Override API base URL (default: `https://api.meshy.ai/openapi`)
+- `MESHY_STREAM_TIMEOUT_MS` (optional) — SSE stream timeout in ms (default: 300000)
+
+Uses `dotenv` to load from `.env` file in dev.

--- a/README.md
+++ b/README.md
@@ -6,11 +6,16 @@ This is a [Model Context Protocol](https://github.com/modelcontextprotocol/model
 
 - **Text-to-3D**: Generate 3D models from text prompts.
 - **Image-to-3D**: Create 3D models from reference images.
+- **Multi-Image-to-3D**: Create 3D models from multiple reference images.
 - **Text-to-Texture**: Apply textures to existing models using text prompts.
+- **Retexture**: Apply new textures to existing 3D models.
+- **Text-to-Image**: Generate images from text prompts.
+- **Image-to-Image**: Generate new images from input images.
 - **Model Optimization**: Remesh and optimize geometry.
 - **Rigging**: Auto-rig 3D characters for animation.
 - **Animation**: Apply animations to rigged characters.
 - **Streaming**: Real-time progress updates for long-running tasks.
+- **Task Deletion**: Delete tasks across all API categories.
 
 ## Installation
 
@@ -101,12 +106,16 @@ npm run dev
 
 ## Available Tools
 
-- **Text to 3D**: `create_text_to_3d_task`, `retrieve_text_to_3d_task`, `list_text_to_3d_tasks`, `stream_text_to_3d_task`
-- **Image to 3D**: `create_image_to_3d_task`, `retrieve_image_to_3d_task`, `list_image_to_3d_tasks`, `stream_image_to_3d_task`
-- **Texturing**: `create_text_to_texture_task`, `retrieve_text_to_texture_task`, `list_text_to_texture_tasks`, `stream_text_to_texture_task`
-- **Remeshing**: `create_remesh_task`, `retrieve_remesh_task`, `list_remesh_tasks`, `stream_remesh_task`
-- **Rigging**: `create_rigging_task`, `retrieve_rigging_task`, `list_rigging_tasks`, `stream_rigging_task`
-- **Animation**: `create_animation_task`, `retrieve_animation_task`, `list_animation_tasks`, `stream_animation_task`
+- **Text to 3D**: `create_text_to_3d_task`, `retrieve_text_to_3d_task`, `list_text_to_3d_tasks`, `stream_text_to_3d_task`, `delete_text_to_3d_task`
+- **Image to 3D**: `create_image_to_3d_task`, `retrieve_image_to_3d_task`, `list_image_to_3d_tasks`, `stream_image_to_3d_task`, `delete_image_to_3d_task`
+- **Multi-Image to 3D**: `create_multi_image_to_3d_task`, `retrieve_multi_image_to_3d_task`, `list_multi_image_to_3d_tasks`, `stream_multi_image_to_3d_task`, `delete_multi_image_to_3d_task`
+- **Texturing**: `create_text_to_texture_task`, `retrieve_text_to_texture_task`, `list_text_to_texture_tasks`, `stream_text_to_texture_task`, `delete_text_to_texture_task`
+- **Retexture**: `create_retexture_task`, `retrieve_retexture_task`, `list_retexture_tasks`, `stream_retexture_task`, `delete_retexture_task`
+- **Text to Image**: `create_text_to_image_task`, `retrieve_text_to_image_task`, `list_text_to_image_tasks`, `stream_text_to_image_task`, `delete_text_to_image_task`
+- **Image to Image**: `create_image_to_image_task`, `retrieve_image_to_image_task`, `list_image_to_image_tasks`, `stream_image_to_image_task`, `delete_image_to_image_task`
+- **Remeshing**: `create_remesh_task`, `retrieve_remesh_task`, `list_remesh_tasks`, `stream_remesh_task`, `delete_remesh_task`
+- **Rigging**: `create_rigging_task`, `retrieve_rigging_task`, `list_rigging_tasks`, `stream_rigging_task`, `delete_rigging_task`
+- **Animation**: `create_animation_task`, `retrieve_animation_task`, `list_animation_tasks`, `stream_animation_task`, `delete_animation_task`
 - **Utility**: `get_balance`
 
 ## License

--- a/src/client.ts
+++ b/src/client.ts
@@ -32,6 +32,19 @@ export class MeshyClient {
     return response.json();
   }
 
+  async delete(path: string, options: RequestOptions = {}): Promise<unknown> {
+    const url = this.buildUrl(path, options.query);
+    const response = await fetch(url, {
+      method: "DELETE",
+      headers: this.headers(),
+      signal: this.buildAbortSignal(options.timeoutMs),
+    });
+
+    await this.ensureOk(response, url);
+    const text = await response.text();
+    return text ? JSON.parse(text) : { success: true };
+  }
+
   async post(path: string, body: unknown, options: RequestOptions = {}): Promise<unknown> {
     const url = this.buildUrl(path, options.query);
     const response = await fetch(url, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -290,7 +290,7 @@ server.registerTool(
       "Create an animation task for a rigged model. The payload must include an action_id from the Meshy animation library.",
     inputSchema: animationPayloadSchema,
   },
-  async (request) => jsonResponse(await client.post("/v1/animation", request)),
+  async (request) => jsonResponse(await client.post("/v1/animations", request)),
 );
 
 server.registerTool(
@@ -299,7 +299,7 @@ server.registerTool(
     description: "Retrieve the status or result of an animation task.",
     inputSchema: z.object({ task_id: z.string() }),
   },
-  async ({ task_id }) => jsonResponse(await client.get(`/v1/animation/${task_id}`)),
+  async ({ task_id }) => jsonResponse(await client.get(`/v1/animations/${task_id}`)),
 );
 
 server.registerTool(
@@ -311,7 +311,7 @@ server.registerTool(
       page: z.number().int().optional(),
     }),
   },
-  async (args = {}) => jsonResponse(await client.get("/v1/animation", { query: args })),
+  async (args = {}) => jsonResponse(await client.get("/v1/animations", { query: args })),
 );
 
 server.registerTool(
@@ -323,8 +323,291 @@ server.registerTool(
       timeout: z.number().int().optional(),
     }),
   },
-  async ({ task_id, timeout }) => jsonResponse(await client.stream(`/v1/animation/${task_id}/stream`, timeout)),
+  async ({ task_id, timeout }) => jsonResponse(await client.stream(`/v1/animations/${task_id}/stream`, timeout)),
 );
+
+// --- Multi Image to 3D ---
+
+server.registerTool(
+  "create_multi_image_to_3d_task",
+  {
+    description: "Generate a 3D model from multiple input images.",
+    inputSchema: z.object({
+      image_urls: z.array(z.string()),
+    }).passthrough(),
+  },
+  async (args) => jsonResponse(await client.post("/v1/multi-image-to-3d", args)),
+);
+
+server.registerTool(
+  "retrieve_multi_image_to_3d_task",
+  {
+    description: "Retrieve the status and result of a multi-image-to-3d task.",
+    inputSchema: z.object({ task_id: z.string() }),
+  },
+  async ({ task_id }) => jsonResponse(await client.get(`/v1/multi-image-to-3d/${task_id}`)),
+);
+
+server.registerTool(
+  "list_multi_image_to_3d_tasks",
+  {
+    description: "List previously created multi-image-to-3d tasks.",
+    inputSchema: z.object({
+      page_size: z.number().int().optional(),
+      page: z.number().int().optional(),
+    }),
+  },
+  async (args = {}) => jsonResponse(await client.get("/v1/multi-image-to-3d", { query: args })),
+);
+
+server.registerTool(
+  "stream_multi_image_to_3d_task",
+  {
+    description: "Stream updates for a multi-image-to-3d task.",
+    inputSchema: z.object({
+      task_id: z.string(),
+      timeout: z.number().int().optional(),
+    }),
+  },
+  async ({ task_id, timeout }) => jsonResponse(await client.stream(`/v1/multi-image-to-3d/${task_id}/stream`, timeout)),
+);
+
+// --- Retexture ---
+
+server.registerTool(
+  "create_retexture_task",
+  {
+    description: "Create a retexture task to apply new textures to an existing 3D model. Provide the request body as defined in the Meshy retexture docs.",
+    inputSchema: z.object({}).passthrough(),
+  },
+  async (args) => jsonResponse(await client.post("/v1/retexture", args)),
+);
+
+server.registerTool(
+  "retrieve_retexture_task",
+  {
+    description: "Retrieve the status and result of a retexture task.",
+    inputSchema: z.object({ task_id: z.string() }),
+  },
+  async ({ task_id }) => jsonResponse(await client.get(`/v1/retexture/${task_id}`)),
+);
+
+server.registerTool(
+  "list_retexture_tasks",
+  {
+    description: "List previously created retexture tasks.",
+    inputSchema: z.object({
+      page_size: z.number().int().optional(),
+      page: z.number().int().optional(),
+    }),
+  },
+  async (args = {}) => jsonResponse(await client.get("/v1/retexture", { query: args })),
+);
+
+server.registerTool(
+  "stream_retexture_task",
+  {
+    description: "Stream updates for a retexture task.",
+    inputSchema: z.object({
+      task_id: z.string(),
+      timeout: z.number().int().optional(),
+    }),
+  },
+  async ({ task_id, timeout }) => jsonResponse(await client.stream(`/v1/retexture/${task_id}/stream`, timeout)),
+);
+
+// --- Text to Image ---
+
+server.registerTool(
+  "create_text_to_image_task",
+  {
+    description: "Generate an image from a text prompt.",
+    inputSchema: z.object({
+      prompt: z.string(),
+      art_style: z.string().optional(),
+      negative_prompt: z.string().optional(),
+      resolution: z.string().optional(),
+    }).passthrough(),
+  },
+  async (args) => jsonResponse(await client.post("/v1/text-to-image", args)),
+);
+
+server.registerTool(
+  "retrieve_text_to_image_task",
+  {
+    description: "Retrieve the status and result of a text-to-image task.",
+    inputSchema: z.object({ task_id: z.string() }),
+  },
+  async ({ task_id }) => jsonResponse(await client.get(`/v1/text-to-image/${task_id}`)),
+);
+
+server.registerTool(
+  "list_text_to_image_tasks",
+  {
+    description: "List previously created text-to-image tasks.",
+    inputSchema: z.object({
+      page_size: z.number().int().optional(),
+      page: z.number().int().optional(),
+    }),
+  },
+  async (args = {}) => jsonResponse(await client.get("/v1/text-to-image", { query: args })),
+);
+
+server.registerTool(
+  "stream_text_to_image_task",
+  {
+    description: "Stream updates for a text-to-image task.",
+    inputSchema: z.object({
+      task_id: z.string(),
+      timeout: z.number().int().optional(),
+    }),
+  },
+  async ({ task_id, timeout }) => jsonResponse(await client.stream(`/v1/text-to-image/${task_id}/stream`, timeout)),
+);
+
+// --- Image to Image ---
+
+server.registerTool(
+  "create_image_to_image_task",
+  {
+    description: "Generate a new image from an input image and optional prompt.",
+    inputSchema: z.object({
+      image_url: z.string(),
+      prompt: z.string().optional(),
+      art_style: z.string().optional(),
+      negative_prompt: z.string().optional(),
+      resolution: z.string().optional(),
+    }).passthrough(),
+  },
+  async (args) => jsonResponse(await client.post("/v1/image-to-image", args)),
+);
+
+server.registerTool(
+  "retrieve_image_to_image_task",
+  {
+    description: "Retrieve the status and result of an image-to-image task.",
+    inputSchema: z.object({ task_id: z.string() }),
+  },
+  async ({ task_id }) => jsonResponse(await client.get(`/v1/image-to-image/${task_id}`)),
+);
+
+server.registerTool(
+  "list_image_to_image_tasks",
+  {
+    description: "List previously created image-to-image tasks.",
+    inputSchema: z.object({
+      page_size: z.number().int().optional(),
+      page: z.number().int().optional(),
+    }),
+  },
+  async (args = {}) => jsonResponse(await client.get("/v1/image-to-image", { query: args })),
+);
+
+server.registerTool(
+  "stream_image_to_image_task",
+  {
+    description: "Stream updates for an image-to-image task.",
+    inputSchema: z.object({
+      task_id: z.string(),
+      timeout: z.number().int().optional(),
+    }),
+  },
+  async ({ task_id, timeout }) => jsonResponse(await client.stream(`/v1/image-to-image/${task_id}/stream`, timeout)),
+);
+
+// --- Delete endpoints ---
+
+server.registerTool(
+  "delete_text_to_3d_task",
+  {
+    description: "Delete a text-to-3d task.",
+    inputSchema: z.object({ task_id: z.string() }),
+  },
+  async ({ task_id }) => jsonResponse(await client.delete(`/v2/text-to-3d/${task_id}`)),
+);
+
+server.registerTool(
+  "delete_image_to_3d_task",
+  {
+    description: "Delete an image-to-3d task.",
+    inputSchema: z.object({ task_id: z.string() }),
+  },
+  async ({ task_id }) => jsonResponse(await client.delete(`/v1/image-to-3d/${task_id}`)),
+);
+
+server.registerTool(
+  "delete_multi_image_to_3d_task",
+  {
+    description: "Delete a multi-image-to-3d task.",
+    inputSchema: z.object({ task_id: z.string() }),
+  },
+  async ({ task_id }) => jsonResponse(await client.delete(`/v1/multi-image-to-3d/${task_id}`)),
+);
+
+server.registerTool(
+  "delete_text_to_texture_task",
+  {
+    description: "Delete a text-to-texture task.",
+    inputSchema: z.object({ task_id: z.string() }),
+  },
+  async ({ task_id }) => jsonResponse(await client.delete(`/v1/text-to-texture/${task_id}`)),
+);
+
+server.registerTool(
+  "delete_remesh_task",
+  {
+    description: "Delete a remesh task.",
+    inputSchema: z.object({ task_id: z.string() }),
+  },
+  async ({ task_id }) => jsonResponse(await client.delete(`/v1/remesh/${task_id}`)),
+);
+
+server.registerTool(
+  "delete_rigging_task",
+  {
+    description: "Delete a rigging task.",
+    inputSchema: z.object({ task_id: z.string() }),
+  },
+  async ({ task_id }) => jsonResponse(await client.delete(`/v1/rigging/${task_id}`)),
+);
+
+server.registerTool(
+  "delete_animation_task",
+  {
+    description: "Delete an animation task.",
+    inputSchema: z.object({ task_id: z.string() }),
+  },
+  async ({ task_id }) => jsonResponse(await client.delete(`/v1/animations/${task_id}`)),
+);
+
+server.registerTool(
+  "delete_retexture_task",
+  {
+    description: "Delete a retexture task.",
+    inputSchema: z.object({ task_id: z.string() }),
+  },
+  async ({ task_id }) => jsonResponse(await client.delete(`/v1/retexture/${task_id}`)),
+);
+
+server.registerTool(
+  "delete_text_to_image_task",
+  {
+    description: "Delete a text-to-image task.",
+    inputSchema: z.object({ task_id: z.string() }),
+  },
+  async ({ task_id }) => jsonResponse(await client.delete(`/v1/text-to-image/${task_id}`)),
+);
+
+server.registerTool(
+  "delete_image_to_image_task",
+  {
+    description: "Delete an image-to-image task.",
+    inputSchema: z.object({ task_id: z.string() }),
+  },
+  async ({ task_id }) => jsonResponse(await client.delete(`/v1/image-to-image/${task_id}`)),
+);
+
+// --- Utility ---
 
 server.registerTool(
   "get_balance",


### PR DESCRIPTION
- Fix animation endpoints using wrong path (/v1/animation → /v1/animations)
- Add multi-image-to-3d endpoints (create, retrieve, list, stream)
- Add retexture endpoints (create, retrieve, list, stream)
- Add text-to-image endpoints (create, retrieve, list, stream)
- Add image-to-image endpoints (create, retrieve, list, stream)
- Add delete endpoints for all 10 API categories
- Add MeshyClient.delete() method
- Add CLAUDE.md for repo guidance